### PR TITLE
Spaces before/after opening/closing paraenthesis

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,13 +62,13 @@ $ git config --global core.autocrlf true
 ```
 
 * Use spaces around operators, after commas, colons and semicolons, around `{`
-  and before `}`. Whitespace might be (mostly) irrelevant to the Elixir runtime,
+  and before `}`. Do not put spaces after the opening or before the closing parenthesis. Whitespace might be (mostly) irrelevant to the Elixir runtime,
   but its proper use is the key to writing easily readable code.
 
 ```Elixir
 sum = 1 + 2
 { a, b } = { 2, 3 }
-Enum.map( ["one", "two", "three"], fn ( num ) -> IO.puts num end )
+Enum.map(["one", "two", "three"], fn (num) -> IO.puts num end)
 ```
 
 * Use empty lines between `def`s and to break up a method into logical


### PR DESCRIPTION
This would be more consistent with the rest of the code style guide.
Additional I like this style.
