### PR TITLE
Rename "symbols" as  "atoms"

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,13 +249,13 @@ end
 
 ## Naming
 
-* Use `snake_case` for symbols, methods and variables.
+* Use `snake_case` for atoms, methods and variables.
 
 ```Elixir
 # bad
-:"some symbol"
-:SomeSymbol
-:someSymbol
+:"some atom"
+:SomeAtom
+:someAtom
 
 someVar = 5
 
@@ -268,7 +268,7 @@ def SomeMethod do
 end
 
 # good
-:some_symbol
+:some_atom
 
 def some_method do
   ...


### PR DESCRIPTION
That's [how the official Getting Started refers to them](http://elixir-lang.org/getting_started/2.html#2.3-atoms).

I just started learning Elixir today, so I'm not sure if there is consensus about this nomenclature or how strict it is... but I decided to open the PR anyway, just in case :)
