### PR TITLE
Add markdownlint file and instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,3 +19,10 @@ formatting/markup/style rules so that the style remains consistent:
   [vim](http://vim.wikia.com/wiki/Automatic_word_wrapping));
 * leave **two newlines** before each first, second and third level header (`#` to `###`) and **one
   newline** before every other type of headers (`####` to `######`).
+
+Install [markdownlint](https://github.com/mivok/markdownlint) to check your
+changes, and run:
+
+```sh
+mdl --style 'markdown.rb' README.md
+```

--- a/markdown.rb
+++ b/markdown.rb
@@ -1,0 +1,9 @@
+all
+
+rule 'MD007', :indent => 4 # Unordered list indentation
+
+exclude_rule 'MD001' # Header levels should only increment by one level at a time
+exclude_rule 'MD012' # Multiple consecutive blank lines
+exclude_rule 'MD014' # Dollar signs used before commands without showing output
+exclude_rule 'MD033' # Inline HTML
+exclude_rule 'MD036' # Emphasis used instead of a header


### PR DESCRIPTION
I'd like to add this style document for the Markdown lint tool (markdownlint). It will help us check PR's for formatting errors, and suggest improvements.

I'll merge it if there are no objections.

We could also set up a commit hook to run the checks automatically.
