### PR TITLE
Add defstruct indentation rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -770,6 +770,13 @@ directives (see [Modules](#modules)).
   defstruct [:name, :params]
   ```
 
+* Indent additional lines of the struct definition, keeping the first keys
+  aligned.
+
+  ```elixir
+  defstruct foo: "test", bar: true, baz: false,
+            qux: false, quux: nil
+  ```
 
 ### Exceptions
 


### PR DESCRIPTION
When a `defstruct` spans multiple lines, the style used by most if not all libraries is to indent the additional lines so that the keys are lined up.

Addresses issue #15 

Examples:

* [Elixir](https://github.com/elixir-lang/elixir/blob/f1cc31be3cecad911f05a536be91857702c2b766/lib/elixir/lib/uri.ex#L10)
* [Ecto](https://github.com/elixir-ecto/ecto/blob/8f1b5222a760c824340e38a66dd935686c66eaf4/lib/ecto/log_entry.ex#L29)
* [Phoenix](https://github.com/phoenixframework/phoenix/blob/297f81c7154149a13f9b61f069f5cc1b43816f3d/lib/phoenix/socket.ex#L139)