### PR TITLE
Add rule about module self-references

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,6 +587,29 @@ If you're looking for other projects to contribute to please see the
   end
   ```
 
+* Use the `__MODULE__` pseudo variable when a module refers to itself. This
+  avoids having to update any self-references when the module name changes.
+
+  ```elixir
+  defmodule SomeProject.SomeModule do
+    defstruct [:name]
+
+    def name(%__MODULE__{name: name}), do: name
+  end
+  ```
+
+* If you want a prettier name for a module self-reference, set up an alias.
+
+  ```elixir
+  defmodule SomeProject.SomeModule do
+    alias __MODULE__, as: SomeModule
+
+    defstruct [:name]
+
+    def name(%SomeModule{name: name}), do: name
+  end
+  ```
+
 
 ### Documentation
 


### PR DESCRIPTION
Adds a note about using `__MODULE__` for self-references.

Addresses issue #22, based on a suggestion by @obrok