### PR TITLE
Markdown rules patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ If you're looking for other projects to contribute to please see the
   setting to protect your project from Windows line endings creeping in:
 
   ```sh
-  $ git config --global core.autocrlf true
+  git config --global core.autocrlf true
   ```
 
 * Use spaces around operators, after commas, colons and semicolons.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # [The Elixir Style Guide][Elixir Style Guide]
 
 
-### Table of Contents
+## Table of Contents
 
 * __[Prelude](#prelude)__
 * __[The Guide](#the-guide)__

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@
 ## Prelude
 
 > Liquid architecture. It's like jazz — you improvise, you work together, you
-> play off each other, you make something, they make something. <br/>
+> play off each other, you make something, they make something.
+>
 > —Frank Gehry
 
 Style matters.

--- a/markdown.rb
+++ b/markdown.rb
@@ -3,5 +3,4 @@ all
 rule 'MD007', :indent => 4 # Unordered list indentation
 
 exclude_rule 'MD012' # Multiple consecutive blank lines
-exclude_rule 'MD033' # Inline HTML
 exclude_rule 'MD036' # Emphasis used instead of a header

--- a/markdown.rb
+++ b/markdown.rb
@@ -2,7 +2,6 @@ all
 
 rule 'MD007', :indent => 4 # Unordered list indentation
 
-exclude_rule 'MD001' # Header levels should only increment by one level at a time
 exclude_rule 'MD012' # Multiple consecutive blank lines
 exclude_rule 'MD033' # Inline HTML
 exclude_rule 'MD036' # Emphasis used instead of a header

--- a/markdown.rb
+++ b/markdown.rb
@@ -4,6 +4,5 @@ rule 'MD007', :indent => 4 # Unordered list indentation
 
 exclude_rule 'MD001' # Header levels should only increment by one level at a time
 exclude_rule 'MD012' # Multiple consecutive blank lines
-exclude_rule 'MD014' # Dollar signs used before commands without showing output
 exclude_rule 'MD033' # Inline HTML
 exclude_rule 'MD036' # Emphasis used instead of a header


### PR DESCRIPTION
Minor formatting changes that obviate a few markdown linter rule exclusions.