### PR TITLE
Add mix task to check header spacing rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+_build
+deps

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,22 @@
 sudo: false
 
-language: ruby
+language: elixir
+
+elixir:
+  - 1.3.1
+
+otp_release:
+  - 19.0
 
 rvm:
   - 2.3.0
 
 install:
   - gem install mdl
+  - mix compile
 
 script:
   - mdl --style 'markdown.rb' README.md
   - mdl --style 'markdown.rb' CONTRIBUTING.md
+  - mix elixir_style_guide.check README.md
+  - mix elixir_style_guide.check CONTRIBUTING.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,12 @@ changes, and run:
 mdl --style 'markdown.rb' README.md
 ```
 
+Check additional style guidelines by installing Elixir and running:
+
+```sh
+mix elixir_style_guide.check README.md
+```
+
 **IMPORTANT**: By submitting a patch, you agree that your work will be
 licensed under the license used by the project.
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ If you're looking for other projects to contribute to please see the
 
 <!-- TODO: Add crafty quote here -->
 
-
 * <a name="spaces-indentation"></a>
   Use two **spaces** per indentation level.
   No hard tabs.

--- a/lib/elixir_style_guide.ex
+++ b/lib/elixir_style_guide.ex
@@ -1,0 +1,2 @@
+defmodule ElixirStyleGuide do
+end

--- a/lib/mix/tasks/elixir_style_guide.check.ex
+++ b/lib/mix/tasks/elixir_style_guide.check.ex
@@ -1,0 +1,77 @@
+defmodule Mix.Tasks.ElixirStyleGuide.Check do
+  use Mix.Task
+
+  @shortdoc "Checks Elixir Style Guide markdown file"
+
+  @errors [
+    [
+      regex: ~r/[^\s]$(?:\n{2}|\n{4,})(\#{1,3}\ .*)$/m,
+      error: "H1/H2/H3 headers should be preceded by two blank lines"
+    ]
+  ]
+
+  def run(args) do
+    {_opts, parsed, _} = OptionParser.parse(args)
+
+    filenames =
+      case parsed do
+        [] -> Mix.raise "missing file"
+        filenames -> filenames
+      end
+
+    filenames
+    |> check_files
+    |> print_reports
+  end
+
+  defp check_files(filenames) when is_list(filenames) do
+    filenames
+    |> Enum.map(&check_file/1)
+    |> List.flatten
+  end
+
+  defp check_file(filename) do
+    {:ok, contents} = File.read(filename)
+
+    errors = check_contents(contents)
+
+    Enum.map(errors, fn error ->
+      Map.put(error, :filename, filename)
+    end)
+  end
+
+  defp check_contents(contents) do
+    @errors
+    |> Enum.map(&(detect_error(&1, contents)))
+    |> List.flatten
+  end
+
+  defp detect_error(error, contents) do
+    regex = error[:regex]
+
+    matches =
+      case Regex.scan(regex, contents, capture: :first) do
+        nil -> []
+        captures -> List.flatten(captures)
+      end
+
+    Enum.map(matches, fn match ->
+      line = count_lines(contents, match)
+      %{line: line, error: error[:error]}
+    end)
+  end
+
+  defp count_lines(contents, match) do
+    [head | _] = String.split(contents, match)
+    content = head <> match
+    newlines = Regex.scan(~r/\n/, content)
+    length(newlines) + 1
+  end
+
+  defp print_reports(reports) do
+    Enum.each(reports, fn report ->
+      error = "#{report.filename}:#{report.line}: #{report.error}"
+      Mix.shell.error(error)
+    end)
+  end
+end

--- a/lib/mix/tasks/elixir_style_guide.check.ex
+++ b/lib/mix/tasks/elixir_style_guide.check.ex
@@ -7,6 +7,10 @@ defmodule Mix.Tasks.ElixirStyleGuide.Check do
     [
       regex: ~r/[^\s]$(?:\n{2}|\n{4,})\#{1,3}\ /m,
       error: "H1/H2/H3 headers should be preceded by two blank lines"
+    ],
+    [
+      regex: ~r/[^\s]$\n{3,}[^\#]/m,
+      error: "Multiple consecutive blank lines"
     ]
   ]
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,0 +1,20 @@
+defmodule ElixirStyleGuide.Mixfile do
+  use Mix.Project
+
+  def project do
+    [app: :elixir_style_guide,
+     version: "0.1.0",
+     elixir: "~> 1.0",
+     build_embedded: Mix.env == :prod,
+     start_permanent: Mix.env == :prod,
+     deps: deps()]
+  end
+
+  def application do
+    [applications: [:logger]]
+  end
+
+  defp deps do
+    []
+  end
+end


### PR DESCRIPTION
* Adds a Mix task to check that exactly two blank lines come before any H1, H2, and H3 header.
* Runs the check automatically on Travis
* Makes it simple to add new rules as long as they can be found with a single regex
* Hopefully make Github recognize this as an "Elixir" project :)

This already helped me find and fix 82c2588

Other ideas for improvement:

* combine with the markdownlint check by calling into the Ruby library directly
* convert to a test rather than a task
* parse the document with earmark, then examine the output of `scan_lines` instead of using a regex