### PR TITLE
Remove self-documenting claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,10 +528,9 @@ If you're looking for other projects to contribute to please see the
 
 ### Comments
 
-* <a name="self-documenting-code"></a>
-  Write self-documenting code and ignore the rest of this section.
-  Seriously!
-  <sup>[[link](#self-documenting-code)]</sup>
+* <a name="expressive-code"></a>
+  Write expressive code and try to convey your program's intention through control-flow, structure and naming.
+  <sup>[[link](#expressive-code)]</sup>
 
 * <a name="comment-leading-spaces"></a>
   Use one space between the leading `#` character of the comment and the text of


### PR DESCRIPTION
Hi Christopher,

it was suggested that I might add some ideas to this style guide of yours.

I would really like to see the following removed/replaced by something less inflamatory:

> Write self-documenting code and ignore the rest of this section. Seriously!

This might have been copy-pasted from the Ruby styleguide. In my mind - however - it has no basis in reality and transports a *bravado* typically not found in the Elixir community. 

It further gives the impression that all decent programmers are able to something called "self documenting code", which does not exist in my opinion; especially when dealing with interfaces to third party code, comments regularly become invaluable.

Since I like to ask people "Oh, won't somebody please think of the newcomers" I would like to propose a different bullet point as a start of the "Comments" section:

> Write expressive code and try to convey your program's intention through control-flow, structure and naming.

Thoughts and suggestions on this are very welcome.