### PR TITLE
Add with expression indentation rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,32 @@ If you're looking for other projects to contribute to please see the
   end
   ```
 
+* <a name="with-clauses"></a>
+  Indent and align successive `with` clauses.
+  Put the `do:` argument on a new line, indented normally.
+  <sup>[[link](#with-clauses)]</sup>
+
+  ```elixir
+  with {:ok, foo} <- fetch(opts, :foo),
+       {:ok, bar} <- fetch(opts, :bar),
+    do: {:ok, foo, bar}
+  ```
+
+* <a name="with-else"></a>
+  If the `with` expression has a `do` block with more than one line, or has an
+  `else` option, use multiline syntax.
+  <sup>[[link](#with-else)]</sup>
+
+  ```elixir
+  with {:ok, foo} <- fetch(opts, :foo),
+       {:ok, bar} <- fetch(opts, :bar) do
+    {:ok, foo, bar}
+  else
+    :error ->
+      {:error, :bad_arg}
+  end
+  ```
+
 ### Naming
 
 * <a name="snake-case"></a>


### PR DESCRIPTION
Adds indentation rules for the `with` special form, styled after the docs, supported by emacs-elixir, and [informally endorsed](https://github.com/elixir-lang/emacs-elixir/pull/348#issuecomment-264713973).

* does not include "not preferred" examples. it seems clear enough without them?
* does not show (yet) how to comment above each `with` clause using parentheses

Addresses issue #101