### PR TITLE
unify term

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,7 +641,7 @@ If you're looking for other projects to contribute to please see the
   <sup>[[link](#one-module-per-file)]</sup>
 
 * <a name="underscored-filenames"></a>
-  Use underscored file names for `CamelCase` module names.
+  Use `snake_case` file names for `CamelCase` module names.
   <sup>[[link](#underscored-filenames)]</sup>
 
   ```elixir


### PR DESCRIPTION
We used the term `snake_case` before, so I think it would be better to call it `snake_case` as well. 