### PR TITLE
Fix @type in `naming-main-types`

### DIFF
--- a/README.md
+++ b/README.md
@@ -918,7 +918,7 @@ directives (see [Modules](#modules)).
   defstruct name: nil, params: []
 
   @type t :: %__MODULE__{
-    name: String.t,
+    name: String.t | nil,
     params: Keyword.t
   }
   ```


### PR DESCRIPTION
The type `t` doesn't match the default struct `%__MODULE__{name: nil, params: []}`. This adds `nil` to the possible types. An alternative would be to default `name` to an empty string.

The reason I'd like to see this extremely nitpicky issue fixed is that this has caused problems with dialyzer in several third-party libraries for me :)