### PR TITLE
Adds @callback, @macrocallback and @optional_callbacks guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -756,6 +756,9 @@ Translations of the guide are available in the following languages:
   1. `defstruct`
   1. `@type`
   1. `@module_attribute`
+  1. `@callback`
+  1. `@macrocallback`
+  1. `@optional_callbacks`
 
   Add a blank line between each grouping, and sort the terms (like module names)
   alphabetically.
@@ -785,6 +788,12 @@ Translations of the guide are available in the following languages:
 
     @module_attribute :foo
     @other_attribute 100
+
+    @callback some_function(term) :: :ok | {:error, term}
+
+    @macrocallback macro_name(term) :: Macro.t
+
+    @optional_callbacks macro_name: 1
 
     ...
   end

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
   * [Modules](#modules)
   * [Documentation](#documentation)
   * [Typespecs](#typespecs)
+  * [Callbacks](#callbacks)
   * [Structs](#structs)
   * [Exceptions](#exceptions)
   * _Collections_
@@ -1026,6 +1027,28 @@ directives (see [Modules](#modules)).
   end
   ```
 
+### Callbacks
+
+Callbacks are used to define [Behaviours].
+
+Callbacks should be defined at the top of your module, right before any
+function (see [Modules](#modules)).
+
+* <a name="callbacks"></a>
+  Each `@callback` or `@macrocallback` should be grouped with its corresponding
+  `@doc`. Separate each pair with a blank line.
+
+  ```elixir
+  @doc "Describe what the callback function should do"
+  @callback operation() :: :ok | {:error, term}
+
+  @doc "Describe what the macro is expected to do"
+  @macrocallback macro_name() :: Macro.t
+  ```
+
+* <a name="callback-types"></a>
+  The types on callbacks should follow the rules for [Typespecs](#typespecs).
+
 ### Structs
 
 * <a name="nil-struct-field-defaults"></a>
@@ -1191,6 +1214,7 @@ Here's the [list of people who have kindly contributed][Contributors] to this
 project.
 
 <!-- Links -->
+[Behaviours]: http://elixir-lang.org/getting-started/typespecs-and-behaviours.html#behaviours
 [Chinese Traditional]: https://github.com/elixirtw/elixir_style_guide/blob/master/README_zhTW.md
 [Code Analysis]: https://github.com/h4cc/awesome-elixir#code-analysis
 [Code Of Conduct]: https://github.com/christopheradams/elixir_style_guide/blob/master/CODE_OF_CONDUCT.md


### PR DESCRIPTION
Adds guides for formatting and module ordering for defining behaviours using `@callback`, `@macrocallback` and `@optional_callbacks`

Closes #139