### PR TITLE
Put union type separator at end of line

### DIFF
--- a/README.md
+++ b/README.md
@@ -986,18 +986,18 @@ directives (see [Modules](#modules)).
 
   ```elixir
   # not preferred - no indentation
-  @type long_union_type :: some_type | another_type | some_other_type
-  | a_final_type
+  @type long_union_type :: some_type | another_type | some_other_type |
+  a_final_type
 
   # preferred
-  @type long_union_type :: some_type | another_type | some_other_type
-                         | a_final_type
+  @type long_union_type :: some_type | another_type | some_other_type |
+                           a_final_type
 
   # also preferred - one type per line
-  @type long_union_type :: some_type
-                         | another_type
-                         | some_other_type
-                         | a_final_type
+  @type long_union_type :: some_type |
+                           another_type |
+                           some_other_type |
+                           a_final_type
   ```
 
 * <a name="naming-main-types"></a>


### PR DESCRIPTION
The Typespecs section has a [rule for union types] that need to be split over multiple lines:

```elixir
@type long_union_type :: some_type
                       | another_type
                       | some_other_type
                       | a_final_type
```

[rule for union types]: https://github.com/christopheradams/elixir_style_guide#union-types

I recall basing the original rule off of a couple of sources:

1. [Typespecs documentation]
1. Erlang standard library (e.g, [code.erl])

[Typespecs documentation]: https://github.com/elixir-lang/elixir/blob/d3f1fff8a9d00ab98e8f48ff02493831ff475d61/lib/elixir/pages/Typespecs.md#basic-types
[code.erl]: https://github.com/erlang/otp/blob/1526eaead833b3bdcd3555a12e2af62c359e7868/lib/kernel/src/code.erl#L88

It would seem the style never caught on. :) The Elixir community currently prefers the separator at the end of the line, like:

```elixir
@type long_union_type :: some_type |
                         another_type |
                         some_other_type |
                         a_final_type
```

For example: [enum.ex], [decimal.ex]

[enum.ex]: https://github.com/elixir-lang/elixir/blob/6bfabdfb69a9c872ac846e958e1814ec6c2138f9/lib/elixir/lib/enum.ex#L80
[decimal.ex]: https://github.com/ericmj/decimal/blob/ec6799d967a1c1f9bc560733334dee34e8ee9a16/lib/decimal.ex#L78

This PR changes the guide to follow the community style, but I'm submitting it here for comments first.

