### PR TITLE
Add rules for Keyword syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,6 +494,18 @@ Translations of the guide are available in the following languages:
   end
   ```
 
+* <a name="keyword-list-syntax"></a>
+  Always use the special syntax for keyword lists.
+  <sup>[[link](#keyword-list-syntax)]</sup>
+
+  ```elixir
+  # not preferred
+  some_value = [{:a, "baz"}, {:b, "qux"}]
+
+  # preferred
+  some_value = [a: "baz", b: "qux"]
+  ```
+
 * <a name="keyword-list-brackets"></a>
   Omit square brackets from keyword lists whenever they are optional.
   <sup>[[link](#keyword-list-brackets)]</sup>

--- a/README.md
+++ b/README.md
@@ -1041,6 +1041,21 @@ directives (see [Modules](#modules)).
   defstruct [:name, :params, active: true]
   ```
 
+* <a name="struct-def-brackets"></a>
+  Omit square brackets when the argument of a `defstruct` is a keyword list.
+  <sup>[[link](#struct-def-brackets)]</sup>
+
+  ```elixir
+  # not preferred
+  defstruct [params: [], active: true]
+
+  # preferred
+  defstruct params: [], active: true
+
+  # required - brackets are not optional, with at least one atom in the list
+  defstruct [:name, params: [], active: true]
+  ```
+
 * <a name="additional-struct-def-lines"></a>
   Indent additional lines of the struct definition, keeping the first keys
   aligned.

--- a/README.md
+++ b/README.md
@@ -494,6 +494,18 @@ Translations of the guide are available in the following languages:
   end
   ```
 
+* <a name="keyword-list-brackets"></a>
+  Omit square brackets from keyword lists whenever they are optional.
+  <sup>[[link](#keyword-list-brackets)]</sup>
+
+  ```elixir
+  # not preferred
+  some_function(foo, bar, [a: "baz", b: "qux"])
+
+  # preferred
+  some_function(foo, bar, a: "baz", b: "qux")
+  ```
+
 * <a name="with-clauses"></a>
   Indent and align successive `with` clauses.
   Put the `do:` argument on a new line, indented normally.


### PR DESCRIPTION
Adds some rules for Keyword lists, including omitting square brackets from a `defstruct` argument (closes #118).

The rule for `defstruct` is not strictly necessary, as it's a logical conclusion of always omitting optional square brackets in a Keyword list, but it will be harder to overlook if it has its own rule.

