### PR TITLE
Added rule for including default values in defdelegate

### DIFF
--- a/README.md
+++ b/README.md
@@ -603,7 +603,6 @@ Translations of the guide are available in the following languages:
   defdelegate some_function(arg1 \\ %{}), to: # module in a.ex
   ```
 
-
 ### Naming
 
 * <a name="snake-case"></a>

--- a/README.md
+++ b/README.md
@@ -590,6 +590,20 @@ Translations of the guide are available in the following languages:
   end
   ```
 
+* <a name="defdelegate-default"></a>
+  In `defdelegate` declarations, include default values that match the original
+  function definition.
+  <sup>[[link](#defdelegate-default)]</sup>
+
+  ```elixir
+  # a.ex
+  def some_function(arg1 \\ %{}), do: # some stuff
+
+  # b.ex
+  defdelegate some_function(arg1 \\ %{}), to: # module in a.ex
+  ```
+
+
 ### Naming
 
 * <a name="snake-case"></a>


### PR DESCRIPTION
Even though they don't seem to be required, putting default values in the `defdelegate` copy of a function header seems like it could help avoid confusion. 

