### PR TITLE
Always use with-clauses with block syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,24 +553,16 @@ Translations of the guide are available in the following languages:
   ```
 
 * <a name="with-clauses"></a>
-  Indent and align successive `with` clauses.
-  Put the `do:` argument on a new line, aligned with the previous clauses.
+  Put a line separator `\` with a space right after the `with` keyword.
+  Always put `with` clauses on separate lines.
+  `do` blocks should start on a new line and use the multiline syntax.
   <sup>[[link](#with-clauses)]</sup>
 
   ```elixir
-  with {:ok, foo} <- fetch(opts, :foo),
-       {:ok, bar} <- fetch(opts, :bar),
-       do: {:ok, foo, bar}
-  ```
-
-* <a name="with-else"></a>
-  If the `with` expression has a `do` block with more than one line, or has an
-  `else` option, use multiline syntax.
-  <sup>[[link](#with-else)]</sup>
-
-  ```elixir
-  with {:ok, foo} <- fetch(opts, :foo),
-       {:ok, bar} <- fetch(opts, :bar) do
+  with \
+    {:ok, foo} <- fetch(opts, :foo),
+    {:ok, bar} <- fetch(opts, :bar)
+  do
     {:ok, foo, bar}
   else
     :error ->


### PR DESCRIPTION
Hi all, I'd like to propose an alternate style for `with` clauses:

We've found that by adding a line separator (`\`) after the `with` clause helps avoid space-mangling editor issues (we use vscode). By entering a new line after  `with \` will help 
* the editor with correctly aligning lines and auto-formatting (even number of indentation spaces)
* with code review readability

So this commit essentially merges the 2 alternate styles for `with`-clauses and proposes to always use the `do...end` block syntax.
