### PR TITLE
Improve indentation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,8 +324,8 @@ are provided here as examples of the preferred style.
 
   ```elixir
   with {:ok, foo} <- fetch(opts, :foo),
-       {:ok, bar} <- fetch(opts, :bar),
-       do: {:ok, foo, bar}
+       {:ok, my_var} <- fetch(opts, :my_var),
+       do: {:ok, foo, my_var}
   ```
 
 * <a name="with-else"></a>
@@ -335,8 +335,8 @@ are provided here as examples of the preferred style.
 
   ```elixir
   with {:ok, foo} <- fetch(opts, :foo),
-       {:ok, bar} <- fetch(opts, :bar) do
-    {:ok, foo, bar}
+       {:ok, my_var} <- fetch(opts, :my_var) do
+    {:ok, foo, my_var}
   else
     :error ->
       {:error, :bad_arg}


### PR DESCRIPTION
In both of the current indentation examples, the left part of the clauses have the same size. 

I think this leaves room for confusion about what should be aligned, if it's the arrows (`<-`) or the start of the clause itself.

I propose to use variables of different sizes to avoid that confusion.