### PR TITLE
Update macros rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1325,7 +1325,7 @@ project.
 [ExDoc]: https://github.com/elixir-lang/ex_doc
 [ExUnit]: https://hexdocs.pm/ex_unit/ExUnit.html
 [French]: https://github.com/ronanboiteau/elixir_style_guide/blob/master/README_frFR.md
-[Guard Expressions]: http://elixir-lang.org/getting-started/case-cond-and-if.html#expressions-in-guard-clauses
+[Guard Expressions]: https://hexdocs.pm/elixir/guards.html#list-of-allowed-expressions
 [Hex]: https://hex.pm/packages
 [Japanese]: https://github.com/kenichirow/elixir_style_guide/blob/master/README-jaJP.md
 [Korean]: https://github.com/marocchino/elixir_style_guide/blob/new-korean/README-koKR.md

--- a/README.md
+++ b/README.md
@@ -660,15 +660,14 @@ generally preferred practice.
   ```
 
 * <a name="predicate-macro-names-with-guards"></a>
-  The names of predicate macros (compile-time generated functions that return a
-  boolean value) _that can be used within guards_ should be prefixed with `is_`.
+  The name of macros suitable for use in guard expressions should be prefixed
+  with `is_`.
   For a list of allowed expressions, see the [Guard][Guard Expressions] docs.
   <sup>[[link](#predicate-macro-names-with-guards)]</sup>
 
   ```elixir
-  defmacro is_cool(var) do
-    quote do: unquote(var) == "cool"
-  end
+  defguard is_cool(var) when var == "cool"
+  defguardp is_very_cool(var) when var == "very cool"
   ```
 
 * <a name="predicate-macro-names-no-guards"></a>


### PR DESCRIPTION
The rule https://github.com/christopheradams/elixir_style_guide#predicate-macro-names-with-guards talks about "predicate macros that can be used within guards". However, Elixir 1.6 introduced `defguard` and `defguardp`, so I think the rules should be updated here as well.

I also updated the docs for valid guard expressions.