### PR TITLE
Fix ambiguous anchor link

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,9 +495,9 @@ generally preferred practice.
   some_string |> String.trim() |> String.downcase() |> String.codepoints()
   ```
 
-* <a name="parentheses"></a>
+* <a name="fun-def-parentheses"></a>
   Use parentheses when a `def` has arguments, and omit them when it doesn't.
-  <sup>[[link](#parentheses)]</sup>
+  <sup>[[link](#fun-def-parentheses)]</sup>
 
   ```elixir
   # not preferred


### PR DESCRIPTION
The anchor link for the following section isn't unique:

> Use parentheses when a def has arguments, and omit them when it doesn't.

It currently points to `#parentheses` which is already used for the another section in the README, so I changed to link to `#fun-def-parentheses`