### PR TITLE
Remove "Syntax" from table of content

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
   * [Whitespace](#whitespace)
   * [Indentation](#indentation)
   * [Parentheses](#parentheses)
-  * [Syntax](#syntax)
 * __[The Guide](#the-guide)__
   * [Expressions](#expressions)
   * [Naming](#naming)


### PR DESCRIPTION
This section has been removed in 005c916ab7f.