### PR TITLE
Switch the order of 'require' and 'alias'

### DIFF
--- a/README.md
+++ b/README.md
@@ -827,8 +827,8 @@ generally preferred practice.
   1. `@behaviour`
   1. `use`
   1. `import`
-  1. `alias`
   1. `require`
+  1. `alias`
   1. `@module_attribute`
   1. `defstruct`
   1. `@type`

--- a/README.md
+++ b/README.md
@@ -854,10 +854,10 @@ generally preferred practice.
     import Something
     import SomethingElse
 
+    require Integer
+
     alias My.Long.Module.Name
     alias My.Other.Module.Example
-
-    require Integer
 
     @module_attribute :foo
     @other_attribute 100


### PR DESCRIPTION
By switching the order of `require` and `alias` it forces you to write the full module when requiring. This makes it more explicit which module is required.