### PR TITLE
Update parentheses in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ are provided here as examples of the preferred style.
   2 |> rem 3 |> g
 
   # preferred
-  2 |> rem(3) |> g
+  2 |> rem(3) |> g()
   ```
 
 * <a name="keyword-list-brackets"></a>


### PR DESCRIPTION
In section `parentheses-pipe-operator` there is parentheses after for one-arity function.